### PR TITLE
Add screenshot of video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Logo](https://user-images.githubusercontent.com/32823481/38769888-7f244cea-400a-11e8-80a7-293dc415c086.png)](https://vimeo.com/user84907397/meet-beyondactivismo)  
+[![Logo](https://raw.githubusercontent.com/Beyondactivismo/Beyondactivismo/master/CI/Logo/meet-BA-vimeo.png)](https://vimeo.com/user84907397/meet-beyondactivismo)  
 _Our goal is to understand what people from different cultures, religions, and countries have in common through their activism. Exploring how activist can help each other, is an amazing but difficult task. With that in mind we are working on an open project that tries to connect and share the histories & experiences of human rights activists, delivering the content in different languages, in attractive and creative ways._
 
 


### PR DESCRIPTION
suggested (possibly temporary) change for the global sprint.
 
Github doesn't allow embedding of videos directly, but using a screenshot of the Vimeo video tells visitors that there is an attractive 1m08 video that they can watch - the existence of the video isn't clear from the logo alone.